### PR TITLE
feat(PESC-006): finish auth flows (signup/login/logout)

### DIFF
--- a/tests/auth/requireAuth.spec.ts
+++ b/tests/auth/requireAuth.spec.ts
@@ -1,0 +1,28 @@
+/** @jest-environment node */
+
+describe('requireAuth guard', () => {
+  afterEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+  })
+
+  it('throws when no session', async () => {
+    jest.mock('@/lib/auth/session', () => ({ getSession: async () => null }))
+    const mod = await import('@/lib/auth/requireAuth')
+    let threw = false
+    try {
+      await mod.requireAuth()
+    } catch (e) {
+      threw = true
+    }
+    expect(threw).toBe(true)
+  })
+
+  it('returns session when present', async () => {
+    const fake = { sub: 'u1', role: 'CLIENT' }
+    jest.mock('@/lib/auth/session', () => ({ getSession: async () => fake }))
+    const mod = await import('@/lib/auth/requireAuth')
+    const session = await mod.requireAuth()
+    expect(session).toEqual(fake)
+  })
+})


### PR DESCRIPTION
Completes PESC-006: adds tests and finalizes basic auth flows (signup, login, logout).

Changes:
- API routes: `/api/auth/signup`, `/api/auth/login`, `/api/auth/logout` using bcrypt + JWT cookie sessions
- Session helpers in `lib/auth/*` and `requireAuth` guard
- Added tests: `tests/auth/flows.spec.ts`, `tests/auth/requireAuth.spec.ts`, plus unit tests for jwt/password/session

Validation:
- All Jest tests pass locally
- TypeScript `tsc --noEmit` passes

Please review and merge when ready.