### PR TITLE
ci: fix Playwright artifact uploads + add debug listing

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -64,6 +64,16 @@ jobs:
         if: steps.check.outputs.has_tests == 'true'
         run: npx playwright test --reporter=list
 
+      - name: Debug: list playwright-report and test-results
+        if: always() && steps.check.outputs.has_tests == 'true'
+        run: |
+          echo '--- listing playwright-report ---'
+          ls -la playwright-report || true
+          echo '--- listing playwright-report/**/trace.zip (glob) ---'
+          ls -la playwright-report/**/trace.zip || true
+          echo '--- listing test-results ---'
+          ls -la test-results || true
+
       - name: Upload Playwright traces
         if: always() && steps.check.outputs.has_tests == 'true'
         uses: actions/upload-artifact@v4
@@ -71,12 +81,21 @@ jobs:
           name: playwright-traces
           path: |
             playwright-report/**/trace.zip
-            test-results/**
             playwright-report
+            test-results/**
+          if-no-files-found: warn
+
+      - name: Debug: confirm report folder before upload
+        if: always() && steps.check.outputs.has_tests == 'true'
+        run: |
+          echo '--- final check: playwright-report root ---'
+          ls -la playwright-report || true
 
       - name: Upload Playwright report
         if: always() && steps.check.outputs.has_tests == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: playwright-report
+          path: |
+            playwright-report
+          if-no-files-found: warn

--- a/.github/workflows/manual-e2e-run.yml
+++ b/.github/workflows/manual-e2e-run.yml
@@ -82,6 +82,15 @@ jobs:
       - name: Run Playwright tests
         run: npx playwright test --reporter=list --reporter=html --reporter=junit
 
+      - name: Debug: list playwright-report and test-results
+        run: |
+          echo '--- listing playwright-report ---'
+          ls -la playwright-report || true
+          echo '--- listing playwright-report/** (glob) ---'
+          ls -la playwright-report/** || true
+          echo '--- listing test-results ---'
+          ls -la test-results || true
+
       - name: Upload Playwright artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -89,3 +98,4 @@ jobs:
           path: |
             playwright-report/**
             test-results/**
+          if-no-files-found: warn


### PR DESCRIPTION
Ensure artifact paths are formatted as multi-line block scalars, add debug ls steps before uploads, and set if-no-files-found: warn so missing artifacts are visible in logs.